### PR TITLE
Add CLI interface for Codex demo

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+const axios = require('axios');
+const vm = require('vm');
+const { Octokit } = require('@octokit/rest');
+
+const apiKey = process.env['OPENAI_API_KEY'];
+const apiOrg = process.env['OPENAI_ORG'];
+const githubPAT = process.env['GITHUB_PAT'];
+
+if (!apiKey) {
+  console.error('OPENAI_API_KEY not set');
+  process.exit(1);
+}
+if (!apiOrg) {
+  console.error('OPENAI_ORG not set');
+  process.exit(1);
+}
+
+const client = axios.create({
+  headers: {
+    Authorization: 'Bearer ' + apiKey,
+    'OpenAI-Organization': apiOrg,
+    'Content-Type': 'application/json'
+  }
+});
+
+async function generateCode(seed, {
+  temperature = 0.5,
+  max_tokens = 100,
+  top_p = 1,
+  frequency_penalty = 0.5,
+  presence_penalty = 0.5,
+  stop = ['});'],
+  engine = 'davinci-codex'
+} = {}) {
+  const endpoint = `https://api.openai.com/v1/engines/${engine}/completions`;
+  const params = {
+    prompt: seed,
+    temperature,
+    max_tokens,
+    top_p,
+    frequency_penalty,
+    presence_penalty,
+    stop
+  };
+  const result = await client.post(endpoint, params);
+  return result.data.choices[0].text;
+}
+
+function runGenerated(code) {
+  const context = { console };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+}
+
+async function main() {
+  const seed = process.argv.slice(2).join(' ') || '//write a nodejs javascript function to say Hello World!';
+  try {
+    const code = await generateCode(seed);
+    console.log('\nGenerated Code:\n');
+    console.log(code);
+    runGenerated(code);
+    if (githubPAT) {
+      const octokit = new Octokit({ auth: githubPAT });
+      await octokit.request('POST /gists', {
+        public: true,
+        files: {
+          'generated.js': { content: code }
+        }
+      });
+    }
+  } catch (err) {
+    console.error('Error generating or running code:', err.message);
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+    ,
+    "cli": "node cli.js"
   },
   "keywords": [],
   "author": "",

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,16 @@ your code and all the processing will output to console.
 
 all successful codex code will end up as a GIST on github as specified by your github PAT and the gist call you make.
 
+## CLI Usage
+If you prefer working in a terminal, you can run the generator without the Express server.
+First install dependencies with `npm install` and then run:
+
+```bash
+npm run cli -- "//write a nodejs javascript function to say Hello from CLI"
+```
+
+This will generate code using the provided seed, execute it locally and upload a Gist if `GITHUB_PAT` is set.
+
 
 
 ## LANGUAGES SUPPORTED


### PR DESCRIPTION
## Summary
- create `cli.js` for running the Codex generator from the terminal
- expose a new npm script `cli`
- document how to run the CLI in the README

## Testing
- `npm test` *(fails: Error: no test specified)*