### PR TITLE
Fix typo in comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ const util = require('util'); // requires --expose_internals
 
 const vm = require('vm');
 
-//Child Process for firing up more node kernals.
+//Child Process for firing up more node kernels.
 var childProcess = require('child_process');
 
 //this is a helper function to run generated code on a virtual machine.

--- a/recipe.js
+++ b/recipe.js
@@ -27,7 +27,7 @@ const { Octokit } = require('@octokit/rest');
 //https://nodejs.org/api/vm.html
 const vm = require('vm');
 
-//Child Process for firing up more node kernals.
+//Child Process for firing up more node kernels.
 var childProcess = require('child_process');
 
 function runScript(scriptPath, callback) {


### PR DESCRIPTION
## Summary
- correct kernel spelling in comments

## Testing
- `npm test` *(fails: Error: no test specified)*