### PR TITLE
Add jest and basic server test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-    ,
+    "test": "jest",
     "cli": "node cli.js"
   },
   "keywords": [],
@@ -16,5 +15,9 @@
     "axios": "^0.21.1",
     "express": "^4.17.1",
     "internal": "^2.0.27"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,25 @@
+const request = require('supertest');
+const { spawn } = require('child_process');
+
+let serverProcess;
+
+beforeAll(done => {
+  serverProcess = spawn('node', ['index.js'], {
+    env: { ...process.env, GITHUB_PAT: 'testtoken' },
+    stdio: 'inherit'
+  });
+  // wait a bit for the server to start
+  setTimeout(done, 1000);
+});
+
+afterAll(() => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+});
+
+test('GET / returns Hello World', async () => {
+  const res = await request('http://localhost:3000').get('/');
+  expect(res.status).toBe(200);
+  expect(res.text).toContain('Hello World!');
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest as dev dependencies
- configure `npm test` to run Jest
- add a test that starts the server and checks the home page

## Testing
- `npm test` *(fails: jest not found)*